### PR TITLE
sshd_config: Simplify type and provider with key as namevar

### DIFF
--- a/lib/puppet/provider/sshd_config/augeas.rb
+++ b/lib/puppet/provider/sshd_config/augeas.rb
@@ -105,11 +105,11 @@ Puppet::Type.type(:sshd_config).provide(:augeas) do
       # Find all unique setting names, then find all instances of it
       settings = aug.match("/files#{file}/*[label()!='Match']").map {|spath|
         self.path_label(spath)
-      }.uniq.reject {|name| name.start_with?("#", "@")}
+      }.uniq.reject {|key| key.start_with?("#", "@")}
 
-      settings.each do |name|
-        value = self.get_value(aug, "/files#{file}/#{name}")
-        entry = {:ensure => :present, :name => name, :value => value}
+      settings.each do |key|
+        value = self.get_value(aug, "/files#{file}/#{key}")
+        entry = {:ensure => :present, :key => key, :value => value}
         resources << new(entry) if entry[:value]
       end
 
@@ -117,19 +117,19 @@ Puppet::Type.type(:sshd_config).provide(:augeas) do
       aug.match("/files#{file}/Match").each do |mpath|
         conditions = []
         aug.match("#{mpath}/Condition/*").each do |cond_path|
-          cond_name = self.path_label(cond_path)
+          cond_key = self.path_label(cond_path)
           cond_value = aug.get(cond_path)
-          conditions.push("#{cond_name} #{cond_value}")
+          conditions.push("#{cond_key} #{cond_value}")
         end
         cond_str = conditions.join(" ")
 
         settings = aug.match("#{mpath}/Settings/*").map {|spath|
           self.path_label(spath)
-        }.uniq.reject {|name| name.start_with?("#", "@")}
+        }.uniq.reject {|key| key.start_with?("#", "@")}
 
-        settings.each do |name|
-          value = self.get_value(aug, "#{mpath}/Settings/#{name}")
-          entry = {:ensure => :present, :name => name,
+        settings.each do |key|
+          value = self.get_value(aug, "#{mpath}/Settings/#{key}")
+          entry = {:ensure => :present, :key => key,
                    :value => value, :condition => cond_str}
           resources << new(entry) if entry[:value]
         end
@@ -155,7 +155,7 @@ Puppet::Type.type(:sshd_config).provide(:augeas) do
 
   def self.entry_path(resource)
     path = "/files#{self.file(resource)}"
-    key = resource[:key] ? resource[:key] : resource[:name]
+    key = resource[:key]
     base = if resource[:condition]
       "#{path}/Match#{self.match_conditions(resource)}/Settings"
     else
@@ -207,7 +207,7 @@ Puppet::Type.type(:sshd_config).provide(:augeas) do
     aug = nil
     path = "/files#{self.class.file(resource)}"
     entry_path = self.class.entry_path(resource)
-    key = resource[:key] ? resource[:key] : resource[:name]
+    key = resource[:key]
     begin
       aug = self.class.augopen(resource)
       if resource[:condition]

--- a/lib/puppet/type/sshd_config.rb
+++ b/lib/puppet/type/sshd_config.rb
@@ -14,14 +14,9 @@ Subsystem entries are not managed by this type. There is a specific `sshd_config
 
   ensurable
 
-  newparam(:name) do
+  newparam(:key) do
     desc "The name of the setting, or a unique string if `condition` given."
     isnamevar
-  end
-
-  newparam(:key) do
-    desc "Overrides setting name to prevent resource conflicts if `condition` is
-given."
   end
 
   newproperty(:value, :array_matching => :all) do

--- a/spec/unit/puppet/sshd_config_spec.rb
+++ b/spec/unit/puppet/sshd_config_spec.rb
@@ -66,7 +66,7 @@ describe provider_class do
       provider_class.stubs(:file).returns(target)
       inst = provider_class.instances.map { |p|
         {
-          :name => p.get(:name),
+          :name => p.get(:key),
           :ensure => p.get(:ensure),
           :value => p.get(:value),
           :condition => p.get(:condition),


### PR DESCRIPTION
Thanks to @crayfishx I just realized I had a bad understanding of `namevar` up to now. This PR simplifies and `sshd_config` type and provider without changing anything of the interface.

There is no need to manage `name` manually, it's automatic in types. By setting `key` as namevar, the overriding process is also automatic, and `key` is set to `name` whenever it is not specified.
