### PR TITLE
Add an alias parameter to sysctl

### DIFF
--- a/lib/puppet/type/sysctl.rb
+++ b/lib/puppet/type/sysctl.rb
@@ -13,6 +13,10 @@ Puppet::Type.newtype(:sysctl) do
     isnamevar
   end
 
+  newproperty(:val) do
+    desc "An alias for 'value'. Maintains interface compatibility with the traditional ParsedFile sysctl provider. If both are set, 'value' will take precedence over 'val'."
+  end
+
   newproperty(:value) do
     desc "Value to change the setting to. Settings with multiple values (such as net.ipv4.tcp_mem are represented as a single whitespace separated string."
   end

--- a/spec/unit/puppet/sysctl_spec.rb
+++ b/spec/unit/puppet/sysctl_spec.rb
@@ -56,6 +56,19 @@ describe provider_class do
       ')
     end
 
+    it "should create an entry using the val parameter instead of value" do
+      apply!(Puppet::Type.type(:sysctl).new(
+        :name     => "net.ipv4.ip_forward",
+        :val      => "1",
+        :target   => target,
+        :provider => "augeas"
+      ))
+
+      augparse(target, "Sysctl.lns", '
+        { "net.ipv4.ip_forward" = "1" }
+      ')
+    end
+
     it "should create new entry with comment" do
       apply!(Puppet::Type.type(:sysctl).new(
         :name     => "net.ipv4.ip_forward",


### PR DESCRIPTION
The quite popular duritong/puppet-sysctl module declares 'val' instead
of 'value' in the type definition.

By adding a 'val' alias here, we present a compatible interface, which
makes replacing it much easier.
