### PR TITLE
shellvar: add support for array values

### DIFF
--- a/docs/examples/shellvar.md
+++ b/docs/examples/shellvar.md
@@ -60,3 +60,48 @@ values themselves.
       target  => "/etc/sysconfig/network",
       comment => "",
     }
+
+### array values
+
+You can pass array values to the type.
+
+There are two ways of rendering array values, and the behavior is set using
+the `array_type` parameter. `array_type` takes three possible values:
+
+* `auto` (default): detects the type of the existing variable, defaults to `string`;
+* `string`: renders the array as a string, with a space as element separator;
+* `array`: renders the array as a shell array.
+
+For example:
+
+    shellvar { "PORTS":
+      ensure     => present,
+      target     => "/etc/default/puppetmaster",
+      value      => ["18140", "18141", "18142"],
+      array_type => "auto",
+    }
+
+will create `PORTS="18140 18141 18142"` by default, and will change `PORTS=(123)` to `PORTS=("18140" "18141" "18142")`.
+
+    shellvar { "PORTS":
+      ensure     => present,
+      target     => "/etc/default/puppetmaster",
+      value      => ["18140", "18141", "18142"],
+      array_type => "string",
+    }
+
+will create `PORTS="18140 18141 18142"` by default, and will change `PORTS=(123)` to `PORTS="18140 18141 18142"`.
+
+    shellvar { "PORTS":
+      ensure     => present,
+      target     => "/etc/default/puppetmaster",
+      value      => ["18140", "18141", "18142"],
+      array_type => "array",
+    }
+
+will create `PORTS=("18140" "18141" "18142")` by default, and will change `PORTS=123` to `PORTS=(18140 18141 18142)`.
+
+Quoting is honored for arrays:
+
+* When using the string behavior, quoting is global to the string;
+* When using the array behavior, each value in the array is quoted as requested.

--- a/lib/puppet/type/shellvar.rb
+++ b/lib/puppet/type/shellvar.rb
@@ -13,8 +13,21 @@ Puppet::Type.newtype(:shellvar) do
     isnamevar
   end
 
-  newproperty(:value) do
+  newproperty(:value, :array_matching => :all) do
     desc "Value to change the variable to."
+
+    munge do |v|
+      v.to_s
+    end
+
+    def insync?(is)
+      case provider.array_type
+      when :string
+        is == Array(should.join(' '))
+      when :array
+        is == should
+      end
+    end
   end
 
   newparam(:quoted) do
@@ -38,6 +51,18 @@ Puppet::Type.newtype(:shellvar) do
         v.to_sym
       end
     end
+  end
+
+  newparam(:array_type) do
+    desc "Type of array mapping to use, defaults to `auto`.
+
+* `auto` will detect the current type, and default to `string`
+* `string` will render the array as a string and use space-separated values
+* `array` will render the array as a shell array"
+
+    newvalues :auto, :string, :array
+
+    defaultto :auto
   end
 
   newparam(:target) do

--- a/spec/fixtures/unit/puppet/shellvar/full
+++ b/spec/fixtures/unit/puppet/shellvar/full
@@ -10,3 +10,6 @@ RETRIES=2
 #SYNC_HWCLOCK=no
 
 EXAMPLE=foo
+
+STR_LIST="foo bar baz"
+LST_LIST=(foo "bar baz" 123)


### PR DESCRIPTION
There are two ways of rendering array values, and the behavior is set using
the `array_type` parameter. `array_type` takes three possible values:
- `auto` (default): detects the type of the existing variable, defaults to `string`;
- `string`: renders the array as a string, with a space as element separator;
- `array`: renders the array as a shell array.

For example:

``` puppet
shellvar { "PORTS":
  ensure     => present,
  target     => "/etc/default/puppetmaster",
  value      => ["18140", "18141", "18142"],
  array_type => "auto",
}
```

will create `PORTS="18140 18141 18142"` by default, and will change `PORTS=(123)` to `PORTS=("18140" "18141" "18142")`.

``` puppet
shellvar { "PORTS":
  ensure     => present,
  target     => "/etc/default/puppetmaster",
  value      => ["18140", "18141", "18142"],
  array_type => "string",
}
```

will create `PORTS="18140 18141 18142"` by default, and will change `PORTS=(123)` to `PORTS="18140 18141 18142"`.

``` puppet
shellvar { "PORTS":
  ensure     => present,
  target     => "/etc/default/puppetmaster",
  value      => ["18140", "18141", "18142"],
  array_type => "array",
}
```

will create `PORTS=("18140" "18141" "18142")` by default, and will change `PORTS=123` to `PORTS=(18140 18141 18142)`.

Quoting is honored for arrays:
- When using the string behavior, quoting is global to the string;
- When using the array behavior, each value in the array is quoted as requested.
