### PR TITLE
Add :array_append parameter to shellvar type/provider

### DIFF
--- a/docs/examples/shellvar.md
+++ b/docs/examples/shellvar.md
@@ -105,3 +105,23 @@ Quoting is honored for arrays:
 
 * When using the string behavior, quoting is global to the string;
 * When using the array behavior, each value in the array is quoted as requested.
+
+### appending to arrays
+
+    shellvar { "GRUB_CMDLINE_LINUX":
+      ensure       => present,
+      target       => "/etc/default/grub",
+      value        => "cgroup_enable=memory",
+      array_append => true,
+    }
+
+will change `GRUB_CMDLINE_LINUX="quiet splash"` to `GRUB_CMDLINE_LINUX="quiet splash cgroup_enable=memory"`.
+
+    shellvar { "GRUB_CMDLINE_LINUX":
+      ensure       => present,
+      target       => "/etc/default/grub",
+      value        => ["quiet", "cgroup_enable=memory"],
+      array_append => true,
+    }
+
+will also change `GRUB_CMDLINE_LINUX="quiet splash"` to `GRUB_CMDLINE_LINUX="quiet splash cgroup_enable=memory"`.

--- a/lib/puppet/provider/shellvar/augeas.rb
+++ b/lib/puppet/provider/shellvar/augeas.rb
@@ -52,7 +52,7 @@ Puppet::Type.type(:shellvar).provide(:augeas) do
     end
   end
 
-  def set_values(path, aug)
+  def set_values(path, aug, values)
     oldvalue = nil
 
     # Detect array type *before* removing subnodes
@@ -62,9 +62,9 @@ Puppet::Type.type(:shellvar).provide(:augeas) do
     case my_array_type
     when :string
       oldvalue = aug.get("#{path}/#{resource[:variable]}")
-      aug.set("#{path}/#{resource[:variable]}", quoteit(resource[:value].join(' '), oldvalue))
+      aug.set("#{path}/#{resource[:variable]}", quoteit(values.join(' '), oldvalue))
     when :array
-      resource[:value].each_with_index do |v, i|
+      values.each_with_index do |v, i|
         aug.set("#{path}/#{resource[:variable]}/#{i}", quoteit(v))
       end
     end
@@ -75,7 +75,7 @@ Puppet::Type.type(:shellvar).provide(:augeas) do
       # Prefer to create the node next to a commented out entry
       commented = aug.match("$target/#comment[.=~regexp('#{resource[:name]}([^a-z\.].*)?')]")
       aug.insert(commented.first, resource[:name], false) unless commented.empty?
-      set_values('$target', aug)
+      set_values('$target', aug, resource[:value])
 
       if resource[:comment]
         aug.insert("$target/#{resource[:variable]}", "#comment", true)
@@ -100,7 +100,7 @@ Puppet::Type.type(:shellvar).provide(:augeas) do
 
   def value=(value)
     augopen! do |aug|
-      set_values('$target', aug)
+      set_values('$target', aug, value)
     end
   end
 

--- a/spec/unit/puppet/shellvar_spec.rb
+++ b/spec/unit/puppet/shellvar_spec.rb
@@ -277,6 +277,22 @@ describe provider_class do
       end
     end
 
+    describe "when using array_append" do
+      it "should not remove existing values" do
+        apply!(Puppet::Type.type(:shellvar).new(
+          :variable     => "STR_LIST",
+          :value        => ["foo", "fooz"],
+          :array_append => true,
+          :target       => target,
+          :provider     => "augeas"
+        ))
+
+        augparse_filter(target, "Shellvars.lns", "STR_LIST", '
+          { "STR_LIST" = "\"foo bar baz fooz\"" }
+        ')
+      end
+    end
+
     describe "when updating comment" do
       it "should add comment" do
         apply!(Puppet::Type.type(:shellvar).new(


### PR DESCRIPTION
See http://serverfault.com/a/557032/29328 for original idea.
### appending to arrays

```
shellvar { "GRUB_CMDLINE_LINUX":
  ensure       => present,
  target       => "/etc/default/grub",
  value        => "cgroup_enable=memory",
  array_append => true,
}
```

will change `GRUB_CMDLINE_LINUX="quiet splash"` to `GRUB_CMDLINE_LINUX="quiet splash cgroup_enable=memory"`.

```
shellvar { "GRUB_CMDLINE_LINUX":
  ensure       => present,
  target       => "/etc/default/grub",
  value        => ["quiet", "cgroup_enable=memory"],
  array_append => true,
}
```

will also change `GRUB_CMDLINE_LINUX="quiet splash"` to `GRUB_CMDLINE_LINUX="quiet splash cgroup_enable=memory"`.
