### PR TITLE
Check for commented lines?

### DIFF
--- a/docs/examples/shellvar.md
+++ b/docs/examples/shellvar.md
@@ -61,6 +61,14 @@ values themselves.
       comment => "",
     }
 
+### replace commented value with entry
+
+    shellvar { "HOSTNAME":
+      ensure    => present,
+      target    => "/etc/sysconfig/network",
+      uncomment => true,
+    }
+
 ### array values
 
 You can pass array values to the type.

--- a/lib/puppet/provider/shellvar/augeas.rb
+++ b/lib/puppet/provider/shellvar/augeas.rb
@@ -74,7 +74,10 @@ Puppet::Type.type(:shellvar).provide(:augeas) do
     augopen! do |aug|
       # Prefer to create the node next to a commented out entry
       commented = aug.match("$target/#comment[.=~regexp('#{resource[:name]}([^a-z\.].*)?')]")
-      aug.insert(commented.first, resource[:name], false) unless commented.empty?
+      unless commented.empty?
+        aug.insert(commented.first, resource[:name], false)
+        aug.rm(commented.first) if resource[:uncomment] == :true
+      end
       set_values('$target', aug, resource[:value])
 
       if resource[:comment]

--- a/lib/puppet/type/shellvar.rb
+++ b/lib/puppet/type/shellvar.rb
@@ -115,6 +115,23 @@ Puppet::Type.newtype(:shellvar) do
     desc "Text to be stored in a comment immediately above the entry.  It will be automatically prepended with the name of the variable in order for the provider to know whether it controls the comment or not."
   end
 
+  newparam(:uncomment) do
+    desc "Whether to remove commented value when found."
+    
+    newvalues :true, :false
+    
+    defaultto :false
+
+    munge do |v|
+      case v
+      when true, "true", :true
+        :true
+      when false, "false", :false
+        :false
+      end
+    end
+  end
+
   autorequire(:file) do
     self[:target]
   end

--- a/spec/unit/puppet/shellvar_spec.rb
+++ b/spec/unit/puppet/shellvar_spec.rb
@@ -94,6 +94,27 @@ describe provider_class do
       ')
     end
 
+    it "should replace comment with new entry" do
+      apply!(Puppet::Type.type(:shellvar).new(
+        :variable  => "SYNC_HWCLOCK",
+        :value     => "yes",
+        :uncomment => true,
+        :target    => target,
+        :provider  => "augeas"
+      ))
+
+      augparse_filter(target, "Shellvars.lns", '*[preceding-sibling::#comment[.=~regexp(".*sync hw clock.*")]]', '
+        { "SYNC_HWCLOCK" = "yes" }
+        { "EXAMPLE" = "foo" }
+        { "STR_LIST" = "\"foo bar baz\"" }
+        { "LST_LIST"
+          { "1" = "foo" }
+          { "2" = "\"bar baz\"" }
+          { "3" = "123" }
+        }
+      ')
+    end
+
     it "should delete entries" do
       apply!(Puppet::Type.type(:shellvar).new(
         :variable => "RETRIES",


### PR DESCRIPTION
As discussed on IRC, augeasproviders doesn't check for comments in lines and you said checking for comments is nice feature request. Ok, here we go :D

Example:
lldpd in debian configured with shellvar. By default file content is:

``` shell
# Uncomment to start SNMP subagent and enable CDP, SONMP and EDP protocol
#DAEMON_ARGS="-x -c -s -e"
```

Ok, let's go with config:

``` puppet
class lldp::config {
    shellvar { 'enable_lldpd':
        ensure   => present,
        target   => '/etc/default/lldpd',
        variable => 'DAEMON_ARGS',
        value    => '-x -c -s -e',
        require  => [
                    Class['lldp::install'],
                    Class['snmp::deploy']
                    ],
        notify  => Service['lldpd']
    }
}
```

Result:

``` shell
# Uncomment to start SNMP subagent and enable CDP, SONMP and EDP protocol
#DAEMON_ARGS="-x -c -s -e"
DAEMON_ARGS="-x -c -s -e"
```
