### PR TITLE
Deactivate autosave when an exception is caught to avoid crashing the Augeas handler

### DIFF
--- a/lib/augeasproviders/provider.rb
+++ b/lib/augeasproviders/provider.rb
@@ -591,6 +591,7 @@ module AugeasProviders::Provider
           aug.close
           aug = nil
         end
+        autosave = false
         raise
       ensure
         augsave!(aug) if block_given? && autosave

--- a/spec/unit/augeasproviders/provider_spec.rb
+++ b/spec/unit/augeasproviders/provider_spec.rb
@@ -275,6 +275,16 @@ describe AugeasProviders::Provider do
           expect { subject.augopen!(resource) {} }.to raise_error
         end
       end
+
+      context "when raising an exception in the block" do
+        it "should to raise the right exception" do
+          expect {
+            subject.augopen! do |aug|
+              raise Puppet::Error, "My error"
+            end
+          }.to raise_error Puppet::Error, "My error"
+        end
+      end
     end
 
     describe "#augsave" do


### PR DESCRIPTION
Currently, if a provider fails in an `augopen` block, the exception is caught in `augopen_internal`, then `augsave!` fails, overriding the original exception. Deactivating `autosave` when an exception is caught avoids this situation.
