### PR TITLE
New shellvars lens breaks unset statements in shellvar provider

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -9,8 +9,13 @@ if [ -z $AUGEAS ]; then
   cd augeas && git pull origin master
   PKG_VERSION=""
 else
-  # Use matching version of lenses
-  cd augeas && git checkout release-${AUGEAS}
+  if [ -z $LENSES ]; then
+    # Use matching version of lenses
+    cd augeas && git checkout release-${AUGEAS}
+  else
+    cd augeas && git checkout $LENSES
+  fi
+
   PKG_VERSION="=${AUGEAS}*"
   # Add PPA
   # We only have working PPAs for precise for 1.0.0 and 1.1.0 for now...

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,30 +11,37 @@ env:
   # Most tests with oldest supported ruby-augeas
   - PUPPET=2.7.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
   - PUPPET=3.0.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
-  - PUPPET=3.2 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
+  - PUPPET=3.2.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
   - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
   # Test the latest ruby-augeas (~>)
-  - PUPPET=3.2 RUBY_AUGEAS=0.5 AUGEAS=1.1.0
-  - PUPPET=3.4 RUBY_AUGEAS=0.5 AUGEAS=1.1.0
+  - PUPPET=3.2.0 RUBY_AUGEAS=0.5
+  - PUPPET=3.4 RUBY_AUGEAS=0.5
   # Test other versions of Augeas
   - PUPPET=2.7.0 RUBY_AUGEAS=0.3.0 AUGEAS=0.10.0
   - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=0.10.0
   - PUPPET=2.7.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0
   - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0
+  - PUPPET=2.7.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
+  - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
   - PUPPET=2.7.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.2.0
   - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.2.0
+  # Issue #83: test old Augeas with new lenses
+  - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0 LENSES=HEAD
+  - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0 LENSES=HEAD
+  - PUPPET=3.4 RUBY_AUGEAS=0.5 AUGEAS=1.0.0 LENSES=HEAD
+  - PUPPET=3.4 RUBY_AUGEAS=0.5 AUGEAS=1.1.0 LENSES=HEAD
 matrix:
   fast_finish: true
   exclude:
-    # No support for Ruby 2.0 before Puppet 3.2 and ruby-augeas 0.5.0
+    # No support for Ruby 2.0 before Puppet 3.2.0 and ruby-augeas 0.5
     - rvm: 2.0.0
       env: PUPPET=2.7.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
     - rvm: 2.0.0
-      env: PUPPET=3.0.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
+      env: PUPPET=3.0.0 RUBY_AUGEAS=0.3.0
     - rvm: 2.0.0
-      env: PUPPET=3.2 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
+      env: PUPPET=3.2.0 RUBY_AUGEAS=0.3.0
     - rvm: 2.0.0
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
+      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0
     - rvm: 2.0.0
       env: PUPPET=2.7.0 RUBY_AUGEAS=0.3.0 AUGEAS=0.10.0
     - rvm: 2.0.0
@@ -44,17 +51,31 @@ matrix:
     - rvm: 2.0.0
       env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0
     - rvm: 2.0.0
+      env: PUPPET=2.7.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
+    - rvm: 2.0.0
+      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
+    - rvm: 2.0.0
       env: PUPPET=2.7.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.2.0
     - rvm: 2.0.0
+      env: PUPPET=3.0.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
+    - rvm: 2.0.0
       env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.2.0
+    - rvm: 2.0.0
+      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0 LENSES=HEAD
+    - rvm: 2.0.0
+      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0 LENSES=HEAD
   allow_failures:
+    # When using new shellvars lens on old Augeas versions
+    # with ruby-augeas 0.3.0 (no text_store support)
     - rvm: 1.8.7
-      env: PUPPET=2.7.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.2.0
+      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0 LENSES=HEAD
     - rvm: 1.8.7
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.2.0
+      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0 LENSES=HEAD
     - rvm: 1.9.3
-      env: PUPPET=2.7.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.2.0
+      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0 LENSES=HEAD
     - rvm: 1.9.3
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.2.0
+      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0 LENSES=HEAD
 install:
   - ./.travis.sh
+script:
+  - AUGEAS_LENS_LIB=augeas/lenses bundle exec rake


### PR DESCRIPTION
`@unset` nodes are now arrays of `seq` entries instead of single values. This breaks the current `shellvar` provider.

The patchset submitted to fix this depends on #80.
