### PR TITLE
Improve errors

### DIFF
--- a/spec/unit/augeasproviders/provider_spec.rb
+++ b/spec/unit/augeasproviders/provider_spec.rb
@@ -371,8 +371,9 @@ describe AugeasProviders::Provider do
       it "should print /augeas//error on save" do
         subject.augopen(resource) do |aug|
           # Prepare an invalid save
+          subject.stubs(:debug)
           aug.rm("/files#{thetarget}/*/ipaddr").should_not == 0
-          lambda { subject.augsave!(aug) }.should raise_error Augeas::Error, /message = Failed to match/
+          lambda { subject.augsave!(aug) }.should raise_error Augeas::Error, /Failed to save Augeas tree/
         end
       end
     end

--- a/spec/unit/puppet/provider/shellvar/augeas_spec.rb
+++ b/spec/unit/puppet/provider/shellvar/augeas_spec.rb
@@ -295,7 +295,7 @@ describe provider_class do
         txn.any_failed?.should_not == nil
         logs_num = Puppet::Util::Package.versioncmp(Puppet.version, '3.4.0') >= 0 ? 1 : 0
         @logs[logs_num].level.should == :err
-        @logs[logs_num].message.include?(target).should == true
+        @logs[logs_num].message.include?('Failed to save').should == true
       end
 
       it "should update string array value as auto string" do


### PR DESCRIPTION
Some ideas to improve errors:
- Use subnodes in `error` to report parse errors
- Improve save errors so they don't look too cryptic

The attached patchset is based on #80 
