### PR TITLE
Add parsed_as? method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,17 +64,6 @@ matrix:
       env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0 LENSES=HEAD
     - rvm: 2.0.0
       env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0 LENSES=HEAD
-  allow_failures:
-    # When using new shellvars lens on old Augeas versions
-    # with ruby-augeas 0.3.0 (no text_store support)
-    - rvm: 1.8.7
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0 LENSES=HEAD
-    - rvm: 1.8.7
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0 LENSES=HEAD
-    - rvm: 1.9.3
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0 LENSES=HEAD
-    - rvm: 1.9.3
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0 LENSES=HEAD
 install:
   - ./.travis.sh
 script:

--- a/lib/puppet/provider/shellvar/augeas.rb
+++ b/lib/puppet/provider/shellvar/augeas.rb
@@ -25,20 +25,7 @@ Puppet::Type.type(:shellvar).provide(:augeas) do
   def unset_seq?
     return @unset_seq unless @unset_seq.nil?
     @unset_seq = Puppet::Util::Package.versioncmp(aug_version, '1.2.0') >= 0
-    unless @unset_seq
-      aug = Augeas.open(nil, nil, Augeas::NO_MODL_AUTOLOAD)
-      begin
-        if aug.respond_to? :text_store
-          aug.set('/input/unset', "unset FOO\n")
-          if aug.text_store('Shellvars.lns', '/input/unset', '/parsed/unset')
-            @unset_seq = aug.match('/parsed/unset/@unset/1').any?
-          end
-        end
-      ensure
-        aug.close
-      end
-    end
-    return @unset_seq
+    @unset_seq ||= parsed_as?("unset FOO\n", '@unset/1')
   end
 
   def unset_path


### PR DESCRIPTION
This PR provides a standard way to check how a lens parses a string, in order to add logical branching for lens versions, such as we did for the shellvar lens in 20af628b6d7ade0535ac7c9de3e799ebafebc449.

Also, it adds a tempfile-based block when `#text_store` is not available, so all tests pass now, even with ruby-augeas 0.3.0.
