### PR TITLE
pam provider ignores password-auth

### DIFF
--- a/lib/puppet/provider/pam/augeas.rb
+++ b/lib/puppet/provider/pam/augeas.rb
@@ -21,8 +21,8 @@ Puppet::Type.type(:pam).provide(:augeas, :parent => Puppet::Type.type(:augeaspro
 
   default_file { '/etc/pam.d/system-auth' }
 
-  def target(resource = nil)
-    if resource and resource[:service]
+  def self.target(resource = nil)
+    if resource and resource[:service] and not resource[:target]
       "/etc/pam.d/#{resource[:service]}".chomp('/')
     else
       super


### PR DESCRIPTION
I have configuration like this

```
class add_radius_config {
  pam { "Add radius authentication to system-auth":
    ensure => present,
    service => "system-auth",
    type => "auth",
    module => "pam_radius_auth.so",
    position => "after module pam_env.so",
    arguments => ["try_first_pass", "localifdown", "conf=/etc/sysconfig/raddb", "client_id=tacacs"],
    control => "sufficient"
  }

  pam { "Add radius authentication password-auth":
    ensure => present,
    service => "password-auth-ac",
    type => "auth",
    module => "pam_radius_auth.so",
    position => "after module pam_env.so",
    arguments => ["try_first_pass", "localifdown", "conf=/etc/sysconfig/raddb", "client_id=tacacs"],
    control => "sufficient",
  }
}
```

For some strange reason, it only applies system-auth, and ignores password-auth 
completely. I cannot see anything in logs about it. If I change system-auth, it will repair the settings, but not for password-auth. 
