### PR TITLE
pam provider should use control as parameter instead of a property

### DIFF
--- a/docs/examples/pam.md
+++ b/docs/examples/pam.md
@@ -63,3 +63,15 @@ This is a custom type and provider supplied by `augeasproviders`.
       arguments => ['try_first_pass','retry=3', 'minlen=10'],
       target    => '/etc/pam.conf',
     }
+
+### allow multiple entries with same control value
+
+    pam { "Set invalid login 3 times deny in password-auth -fail":
+      ensure           => present,
+      service          => 'password-auth',
+      type             => 'auth',
+      control          => '[default=die]',
+      control_is_param => true,
+      module           => 'pam_faillock.so',
+      arguments        => ['authfail','deny=3','unlock_time=604800','fail_interval=900'],
+    }

--- a/lib/puppet/provider/pam/augeas.rb
+++ b/lib/puppet/provider/pam/augeas.rb
@@ -37,10 +37,11 @@ Puppet::Type.type(:pam).provide(:augeas, :parent => Puppet::Type.type(:augeaspro
     service = resource[:service]
     type = resource[:type]
     mod = resource[:module]
+    control_cond = (resource[:control_is_param] == :true) ? "and control='#{resource[:control]}'" : ''
     if target == '/etc/pam.conf'
-      "$target/*[service='#{service}' and type='#{type}' and module='#{mod}']"
+      "$target/*[service='#{service}' and type='#{type}' and module='#{mod}' #{control_cond}]"
     else
-      "$target/*[type='#{type}' and module='#{mod}']"
+      "$target/*[type='#{type}' and module='#{mod}' #{control_cond}]"
     end
   end
 

--- a/lib/puppet/type/pam.rb
+++ b/lib/puppet/type/pam.rb
@@ -63,6 +63,17 @@ filename under /etc/pam.d"
     desc "Simple or complex definition of the module's behavior on failure."
   end
 
+  newparam(:control_is_param, :boolean => true) do
+    desc "Whether `control` should be considered a parameter or a property."
+
+    newvalues :false, :true
+    defaultto :false
+
+    munge do |value|
+      @resource.munge_boolean(value)
+    end
+  end
+
   newparam(:position) do
     desc "A three part text field that providers the placement position of an entry.
 


### PR DESCRIPTION
The scap-security-guide has a few security rules it checks for that involve having two different entries with the same type and module but a different control. I can't speak for whether or not the recommended pam config is valid (and I don't even care if anyone is ever able to log into this puppet configured server but if someone runs a security scan I want these checks to "pass"). 

@raphink says: 
_Indeed, control is a property, not a parameter, so it is meant to converge for a given combination of service and type. If you think this is a bug, please open a new ticket to request control to be used as a parameter instead._

Here is the verbiage from the scap scan report (there are couple other security findings that are addressed by the same two pam entries). 

Result for Set Deny For Failed Password Attempts
Result: fail
Rule ID: accounts_passwords_pam_faillock_deny
Time: 2014-05-29 16:07
Severity: medium

To configure the system to lock out accounts after a number of incorrect login attempts using pam_faillock.so: 

Add the following lines immediately below the pam_unix.so statement in AUTH section of both /etc/pam.d/system-auth and /etc/pam.d/password-auth: 

```
auth [default=die] pam_faillock.so authfail deny=3 unlock_time=604800 fail_interval=900
auth required pam_faillock.so authsucc deny=3 unlock_time=604800 fail_interval=900
```

Locking out user accounts after a number of incorrect attempts prevents direct password guessing attacks. 

Security identifiers
CCE-26844-1
