### PR TITLE
pam: Could not set 'present' on ensure: undefined method `each' for nil:NilClass if arguments is not define

### DIFF
--- a/lib/puppet/type/pam.rb
+++ b/lib/puppet/type/pam.rb
@@ -57,6 +57,7 @@ filename under /etc/pam.d"
 
   newproperty(:arguments, :array_matching => :all) do
     desc "Arguments to assign for the module."
+    defaultto { [] }
   end
 
   newproperty(:control) do

--- a/spec/unit/puppet/provider/pam/augeas_spec.rb
+++ b/spec/unit/puppet/provider/pam/augeas_spec.rb
@@ -33,6 +33,24 @@ describe provider_class do
       end
     end
 
+    it "should create simple new entry without arguments" do
+      apply!(Puppet::Type.type(:pam).new(
+        :title       => "Add pam_test.so to auth for system-auth",
+        :service     => "system-auth",
+        :type        => "auth",
+        :control     => "sufficient",
+        :module      => "pam_test.so",
+        :target      => target,
+        :provider    => "augeas",
+        :ensure      => "present"
+      ))
+
+      aug_open(target, "Pam.lns") do |aug|
+        aug.get("./1/module").should == "pam_test.so"
+        aug.match("./1/argument").size.should == 0
+      end
+    end
+
     it "should create two new entries" do
       apply!(Puppet::Type.type(:pam).new(
         :title       => "Add pam_test.so to auth for system-auth",


### PR DESCRIPTION
The following code breaks puppet:

```
    pam { 'include_password-auth':
      service  => 'sshd',
      type     => 'auth',
      module   => 'password-auth',
      control  => 'include',
      position => 'after last',
    }
```

Here is the error:

```
Error: Could not set 'present' on ensure: undefined method `each' for nil:NilClass at 98:/***.pp
/var/lib/puppet/lib/puppet/provider/pam/augeas.rb:106
/var/lib/puppet/lib/augeasproviders/provider.rb:701:in `call'
/var/lib/puppet/lib/augeasproviders/provider.rb:701:in `augopen_internal'
/var/lib/puppet/lib/augeasproviders/provider.rb:146:in `augopen!'
/var/lib/puppet/lib/augeasproviders/provider.rb:786:in `augopen!'
/var/lib/puppet/lib/augeasproviders/provider.rb:201:in `create'
/usr/lib/ruby/site_ruby/1.8/puppet/property/ensure.rb:16:in `set_present'
/usr/lib/ruby/site_ruby/1.8/puppet/property.rb:197:in `send'
/usr/lib/ruby/site_ruby/1.8/puppet/property.rb:197:in `call_valuemethod'
/usr/lib/ruby/site_ruby/1.8/puppet/property.rb:498:in `set'
.....
```

Adding a ''arguments => []'' works:

```
    pam { 'include_password-auth':
      service  => 'sshd',
      type     => 'auth',
      module   => 'password-auth',
      control  => 'include',
      position => 'after last',
      arguments => []
    }
```
