### PR TITLE
Fix true? errors in specs by being more specific

### DIFF
--- a/spec/lib/augeas_spec/fixtures.rb
+++ b/spec/lib/augeas_spec/fixtures.rb
@@ -31,7 +31,7 @@ module AugeasSpec::Fixtures
     @logs.select { |log| loglevels.include? log.level }.should == []
 
     # Check for transaction success after, as it's less informative
-    txn.any_failed?.should_not be_true
+    txn.any_failed?.should be_nil
 
     # Run the exact same resources, but this time ensure there were absolutely
     # no changes (as seen by logs) to indicate if it was idempotent or not
@@ -41,7 +41,7 @@ module AugeasSpec::Fixtures
     againlogs = @logs.select { |log| loglevels.include? log.level }
 
     againlogs.should eq([]), "expected no change on second run (idempotence check),\n     got: #{againlogs.inspect}"
-    txn_idempotent.any_failed?.should_not be_true, "expected no change on second run (idempotence check), got a resource failure"
+    txn_idempotent.any_failed?.should be_nil, "expected no change on second run (idempotence check), got a resource failure"
 
     @logs = firstlogs
     txn

--- a/spec/unit/puppet/provider/augeasprovider/default_spec.rb
+++ b/spec/unit/puppet/provider/augeasprovider/default_spec.rb
@@ -168,14 +168,14 @@ describe provider_class do
     describe "#attr_aug_reader" do
       it "should create a class method" do
         subject.attr_aug_reader(:foo, {})
-        subject.method_defined?('attr_aug_reader_foo').should be_true
+        subject.method_defined?('attr_aug_reader_foo').should == true
       end
     end
 
     describe "#attr_aug_writer" do
       it "should create a class method" do
         subject.attr_aug_writer(:foo, {})
-        subject.method_defined?('attr_aug_writer_foo').should be_true
+        subject.method_defined?('attr_aug_writer_foo').should == true
       end
     end
 
@@ -480,7 +480,7 @@ describe provider_class do
     describe "#attr_aug_reader" do
       it "should create a class method using :string" do
         subject.attr_aug_reader(:foo, {})
-        subject.method_defined?('attr_aug_reader_foo').should be_true
+        subject.method_defined?('attr_aug_reader_foo').should == true
 
         Augeas.any_instance.expects(:get).with('$resource/foo').returns('bar')
         subject.augopen(resource) do |aug|
@@ -490,7 +490,7 @@ describe provider_class do
 
       it "should create a class method using :array and no sublabel" do
         subject.attr_aug_reader(:foo, { :type => :array })
-        subject.method_defined?('attr_aug_reader_foo').should be_true
+        subject.method_defined?('attr_aug_reader_foo').should == true
 
         rpath = "/files#{thetarget}/test/foo"
         subject.augopen(resource) do |aug|
@@ -503,7 +503,7 @@ describe provider_class do
 
       it "should create a class method using :array and a :seq sublabel" do
         subject.attr_aug_reader(:foo, { :type => :array, :sublabel => :seq })
-        subject.method_defined?('attr_aug_reader_foo').should be_true
+        subject.method_defined?('attr_aug_reader_foo').should == true
 
         rpath = "/files#{thetarget}/test/foo"
         subject.augopen(resource) do |aug|
@@ -519,7 +519,7 @@ describe provider_class do
 
       it "should create a class method using :array and a string sublabel" do
         subject.attr_aug_reader(:foo, { :type => :array, :sublabel => 'sl' })
-        subject.method_defined?('attr_aug_reader_foo').should be_true
+        subject.method_defined?('attr_aug_reader_foo').should == true
 
         rpath = "/files#{thetarget}/test/foo"
         subject.augopen(resource) do |aug|
@@ -541,7 +541,7 @@ describe provider_class do
 
       it "should create a class method using :hash and sublabel" do
         subject.attr_aug_reader(:foo, { :type => :hash, :sublabel => 'sl', :default => 'deflt' })
-        subject.method_defined?('attr_aug_reader_foo').should be_true
+        subject.method_defined?('attr_aug_reader_foo').should == true
 
         rpath = "/files#{thetarget}/test/foo"
         subject.augopen(resource) do |aug|
@@ -564,7 +564,7 @@ describe provider_class do
     describe "#attr_aug_writer" do
       it "should create a class method using :string" do
         subject.attr_aug_writer(:foo, {})
-        subject.method_defined?('attr_aug_writer_foo').should be_true
+        subject.method_defined?('attr_aug_writer_foo').should == true
 
         subject.augopen(resource) do |aug|
           aug.expects(:set).with('$resource/foo', 'bar')
@@ -576,7 +576,7 @@ describe provider_class do
 
       it "should create a class method using :string with :rm_node" do
         subject.attr_aug_writer(:foo, { :rm_node => true })
-        subject.method_defined?('attr_aug_writer_foo').should be_true
+        subject.method_defined?('attr_aug_writer_foo').should == true
 
         subject.augopen(resource) do |aug|
           aug.expects(:set).with('$resource/foo', 'bar')
@@ -588,7 +588,7 @@ describe provider_class do
 
       it "should create a class method using :array and no sublabel" do
         subject.attr_aug_writer(:foo, { :type => :array })
-        subject.method_defined?('attr_aug_writer_foo').should be_true
+        subject.method_defined?('attr_aug_writer_foo').should == true
 
         subject.augopen(resource) do |aug|
           aug.expects(:rm).with('$resource/foo')
@@ -602,7 +602,7 @@ describe provider_class do
 
       it "should create a class method using :array and a :seq sublabel" do
         subject.attr_aug_writer(:foo, { :type => :array, :sublabel => :seq })
-        subject.method_defined?('attr_aug_writer_foo').should be_true
+        subject.method_defined?('attr_aug_writer_foo').should == true
 
         subject.augopen(resource) do |aug|
           aug.expects(:rm).with('$resource/foo')
@@ -616,7 +616,7 @@ describe provider_class do
 
       it "should create a class method using :array and a string sublabel" do
         subject.attr_aug_writer(:foo, { :type => :array, :sublabel => 'sl' })
-        subject.method_defined?('attr_aug_writer_foo').should be_true
+        subject.method_defined?('attr_aug_writer_foo').should == true
 
         subject.augopen(resource) do |aug|
           aug.expects(:rm).with('$resource/foo')
@@ -636,7 +636,7 @@ describe provider_class do
 
       it "should create a class method using :hash and sublabel" do
         subject.attr_aug_writer(:foo, { :type => :hash, :sublabel => 'sl', :default => 'deflt' })
-        subject.method_defined?('attr_aug_writer_foo').should be_true
+        subject.method_defined?('attr_aug_writer_foo').should == true
 
         rpath = "/files#{thetarget}/test/foo"
         subject.augopen(resource) do |aug|


### PR DESCRIPTION
`be_true` fails recently (maybe because Rspec3 is out, I don't actually know) because it calls `true?`, which is not a valid method for quite a few classes (at least in Ruby 1.9.3).

This PR fixes it by not using `be_true` and being more specific instead.
