### PR TITLE
Rsyslog manage remote hostname entry: can't set port with ":" delimiter alongside hostname

### DIFF
--- a/docs/examples/syslog.md
+++ b/docs/examples/syslog.md
@@ -35,6 +35,18 @@ handles the extended rsyslog config (this requires Augeas 1.0.0).
       action      => "centralserver",
     }
 
+### manage remote hostname entry with port and protocol
+
+    syslog { "my test":
+      ensure          => present,
+      facility        => "local2",
+      level           => "*",
+      action_type     => "hostname",
+      action_port     => "514",
+      action_protocol => "tcp",
+      action          => "centralserver",
+    }
+
 ### manage user destination entry
 
     syslog { "my test":

--- a/lib/puppet/type/syslog.rb
+++ b/lib/puppet/type/syslog.rb
@@ -36,6 +36,24 @@ Puppet::Type.newtype(:syslog) do
     desc "The type of action: file, hostname, user or program."
   end
 
+  newparam(:action_protocol) do
+    desc "When action is hostname, the optional protocol."
+    newvalues :udp, :tcp, :'@', :'@@'
+
+    munge do |value|
+    case value
+      when :udp, 'udp', :'@', '@'
+        '@'
+      when :tcp, 'tcp', :'@@', '@@'
+        '@@'
+      end
+    end
+  end
+
+  newparam(:action_port) do
+    desc "When action is hostname, the optional port."
+  end
+
   newparam(:action) do
     desc "The action for the entry."
   end

--- a/spec/unit/puppet/provider/syslog/augeas_spec.rb
+++ b/spec/unit/puppet/provider/syslog/augeas_spec.rb
@@ -12,6 +12,8 @@ describe provider_class do
     FileTest.stubs(:exist?).with('/etc/syslog.conf').returns true
   end
 
+  let(:protocol_supported?) { subject.protocol_supported? }
+
   context "with empty file" do
     let(:tmptarget) { aug_fixture("empty") }
     let(:target) { tmptarget.path }
@@ -32,6 +34,119 @@ describe provider_class do
         aug.match("entry").size.should == 1
         aug.get("entry/action/file").should == "/var/log/test.log"
         aug.match("entry/action/no_sync").size.should == 0
+      end
+    end
+
+    it "should create hostname entry with tcp protocol" do
+      if protocol_supported?
+        apply!(Puppet::Type.type(:syslog).new(
+          :name            => "hostname test",
+          :facility        => "*",
+          :level           => "*",
+          :action_type     => "hostname",
+          :action_protocol => "tcp",
+          :action          => "remote-host",
+          :target          => target,
+          :provider        => "augeas",
+          :ensure          => "present"
+        ))
+
+        aug_open(target, "Syslog.lns") do |aug|
+          aug.match("entry").size.should == 1
+          aug.get("entry/action/protocol").should == "@@"
+          aug.match("entry/action/port").size.should == 0
+        end
+      else
+        txn = apply(Puppet::Type.type(:syslog).new(
+          :name            => "hostname test",
+          :facility        => "*",
+          :level           => "*",
+          :action_type     => "hostname",
+          :action_protocol => "tcp",
+          :action          => "remote-host",
+          :target          => target,
+          :provider        => "augeas",
+          :ensure          => "present"
+        ))
+        txn.any_failed?.should_not == nil
+        @logs[0].level.should == :err
+        @logs[0].message.include?('Protocol is not supported').should == true
+      end
+    end
+
+    it "should create hostname entry with udp protocol" do
+      if protocol_supported?
+        apply!(Puppet::Type.type(:syslog).new(
+          :name            => "hostname test",
+          :facility        => "*",
+          :level           => "*",
+          :action_type     => "hostname",
+          :action_protocol => "udp",
+          :action          => "remote-host",
+          :target          => target,
+          :provider        => "augeas",
+          :ensure          => "present"
+        ))
+
+        aug_open(target, "Syslog.lns") do |aug|
+          aug.match("entry").size.should == 1
+          aug.get("entry/action/protocol").should == "@"
+          aug.match("entry/action/port").size.should == 0
+        end
+      else
+        txn = apply(Puppet::Type.type(:syslog).new(
+          :name            => "hostname test",
+          :facility        => "*",
+          :level           => "*",
+          :action_type     => "hostname",
+          :action_protocol => "udp",
+          :action          => "remote-host",
+          :target          => target,
+          :provider        => "augeas",
+          :ensure          => "present"
+        ))
+        txn.any_failed?.should_not == nil
+        @logs[0].level.should == :err
+        @logs[0].message.include?('Protocol is not supported').should == true
+      end
+    end
+
+    it "should create hostname entry with port" do
+      if protocol_supported?  # port requires protocol
+        apply!(Puppet::Type.type(:syslog).new(
+          :name            => "hostname test",
+          :facility        => "*",
+          :level           => "*",
+          :action_type     => "hostname",
+          :action_port     => "514",
+          :action_protocol => "tcp",
+          :action          => "remote-host",
+          :target          => target,
+          :provider        => "augeas",
+          :ensure          => "present"
+        ))
+
+        aug_open(target, "Syslog.lns") do |aug|
+          aug.match("entry").size.should == 1
+          aug.get("entry/action/protocol").should == "@@"
+          aug.get("entry/action/port").should == "514"
+        end
+      else
+        txn = apply(Puppet::Type.type(:syslog).new(
+          :name            => "hostname test",
+          :facility        => "*",
+          :level           => "*",
+          :action_type     => "hostname",
+          :action_port     => "514",
+          :action_protocol => "tcp",
+          :action          => "remote-host",
+          :target          => target,
+          :provider        => "augeas",
+          :ensure          => "present"
+        ))
+        txn.any_failed?.should_not == nil
+        @logs[0].level.should == :err
+        @logs[0].message.include?('Protocol is not supported').should == true
       end
     end
   end


### PR DESCRIPTION
I'm trying to set the port along side the hostname for "remote server" as seen below.  This is how it should appear in /etc/rsyslog.conf.  This isn't working.  Not sure if there is an attribute for the port number i can use, but i'm assuming strange characters as ":" and such aren't supported in this attribute.  
### the block

``` puppet
syslog { "cortez_test":
  ensure      => present,
  facility    => "*",
  level       => "*",
  action_type => "hostname",
  action      => "testserver:514",
  provider    => "rsyslog",
}
```
### the results

``` puppet
[root@tstctlvopenpt04 test]# puppet apply /root/test/init.pp
Notice: Compiled catalog for tstctlvopenpt04.iteclientsys.local in environment production in 0.05 seconds
Error: Could not set 'present' on ensure: /augeas/files/etc/rsyslog.conf/error/path = /files/etc/rsyslog.conf/entry/action
/augeas/files/etc/rsyslog.conf/error/lens = /usr/share/augeas/lenses/dist/rsyslog.aug:41.16-.39:
/augeas/files/etc/rsyslog.conf/error/message = Failed to match
    { /no_sync/ }?{ /file/ = /\/[^\001-\004\t\n ]+/ } | { /hostname/ = /[0-9A-Za-z]([0-9A-Za-z-]*[0-9A-Za-z])?(\\.[0-9A-Za-z]([0-9A-Za-z-]*[0-9A-Za-z])?)*/ }({ /port/ = /[0-9]+/ })? | { /user/ = /[0-9A-Za-z][.0-9A-Z_a-z-]*/ }({ /user/ = /[0-9A-Za-z][.0-9A-Z_a-z-]*/ })* | { /user/ = /\\*/ } | { /program/ = /[^\001-\004\t\n ][^\001-\004\n]+[^\001-\004\t\n ]/ } | { /omusrmsg/ = /[0-9A-Za-z][.0-9A-Z_a-z-]*/ }({ /omusrmsg/ = /[0-9A-Za-z][.0-9A-Z_a-z-]*/ })* | { /omusrmsg/ = /\\*/ }
  with tree
    { "hostname" = "testserver:514" } at 10:/root/test/init.pp
Error: Could not set 'present' on ensure: /augeas/files/etc/rsyslog.conf/error/path = /files/etc/rsyslog.conf/entry/action
/augeas/files/etc/rsyslog.conf/error/lens = /usr/share/augeas/lenses/dist/rsyslog.aug:41.16-.39:
/augeas/files/etc/rsyslog.conf/error/message = Failed to match
    { /no_sync/ }?{ /file/ = /\/[^\001-\004\t\n ]+/ } | { /hostname/ = /[0-9A-Za-z]([0-9A-Za-z-]*[0-9A-Za-z])?(\\.[0-9A-Za-z]([0-9A-Za-z-]*[0-9A-Za-z])?)*/ }({ /port/ = /[0-9]+/ })? | { /user/ = /[0-9A-Za-z][.0-9A-Z_a-z-]*/ }({ /user/ = /[0-9A-Za-z][.0-9A-Z_a-z-]*/ })* | { /user/ = /\\*/ } | { /program/ = /[^\001-\004\t\n ][^\001-\004\n]+[^\001-\004\t\n ]/ } | { /omusrmsg/ = /[0-9A-Za-z][.0-9A-Z_a-z-]*/ }({ /omusrmsg/ = /[0-9A-Za-z][.0-9A-Z_a-z-]*/ })* | { /omusrmsg/ = /\\*/ }
  with tree
    { "hostname" = "testserver:514" } at 10:/root/test/init.pp
Wrapped exception:
/augeas/files/etc/rsyslog.conf/error/path = /files/etc/rsyslog.conf/entry/action
/augeas/files/etc/rsyslog.conf/error/lens = /usr/share/augeas/lenses/dist/rsyslog.aug:41.16-.39:
/augeas/files/etc/rsyslog.conf/error/message = Failed to match
    { /no_sync/ }?{ /file/ = /\/[^\001-\004\t\n ]+/ } | { /hostname/ = /[0-9A-Za-z]([0-9A-Za-z-]*[0-9A-Za-z])?(\\.[0-9A-Za-z]([0-9A-Za-z-]*[0-9A-Za-z])?)*/ }({ /port/ = /[0-9]+/ })? | { /user/ = /[0-9A-Za-z][.0-9A-Z_a-z-]*/ }({ /user/ = /[0-9A-Za-z][.0-9A-Z_a-z-]*/ })* | { /user/ = /\\*/ } | { /program/ = /[^\001-\004\t\n ][^\001-\004\n]+[^\001-\004\t\n ]/ } | { /omusrmsg/ = /[0-9A-Za-z][.0-9A-Z_a-z-]*/ }({ /omusrmsg/ = /[0-9A-Za-z][.0-9A-Z_a-z-]*/ })* | { /omusrmsg/ = /\\*/ }
  with tree
    { "hostname" = "testserver:514" }
Error: /Stage[main]//Syslog[cortez_test]/ensure: change from absent to present failed: Could not set 'present' on ensure: /augeas/files/etc/rsyslog.conf/error/path = /files/etc/rsyslog.conf/entry/action
/augeas/files/etc/rsyslog.conf/error/lens = /usr/share/augeas/lenses/dist/rsyslog.aug:41.16-.39:
/augeas/files/etc/rsyslog.conf/error/message = Failed to match
    { /no_sync/ }?{ /file/ = /\/[^\001-\004\t\n ]+/ } | { /hostname/ = /[0-9A-Za-z]([0-9A-Za-z-]*[0-9A-Za-z])?(\\.[0-9A-Za-z]([0-9A-Za-z-]*[0-9A-Za-z])?)*/ }({ /port/ = /[0-9]+/ })? | { /user/ = /[0-9A-Za-z][.0-9A-Z_a-z-]*/ }({ /user/ = /[0-9A-Za-z][.0-9A-Z_a-z-]*/ })* | { /user/ = /\\*/ } | { /program/ = /[^\001-\004\t\n ][^\001-\004\n]+[^\001-\004\t\n ]/ } | { /omusrmsg/ = /[0-9A-Za-z][.0-9A-Z_a-z-]*/ }({ /omusrmsg/ = /[0-9A-Za-z][.0-9A-Z_a-z-]*/ })* | { /omusrmsg/ = /\\*/ }
  with tree
    { "hostname" = "testserver:514" } at 10:/root/test/init.pp
Notice: Finished catalog run in 0.12 seconds
```
