### PR TITLE
use different variable for namevar

### DIFF
--- a/lib/puppet/type/shellvar.rb
+++ b/lib/puppet/type/shellvar.rb
@@ -48,9 +48,14 @@ Puppet::Type.newtype(:shellvar) do
     end
   end
 
+  newparam(:title) do
+    desc "Title of the resource"
+    isnamevar
+  end
+
   newparam(:variable) do
     desc "The name of the variable, e.g. OPTIONS"
-    isnamevar
+    defaultto :title
   end
 
   newproperty(:value, :array_matching => :all) do


### PR DESCRIPTION
this makes it possible to actually set the same variable in two
different files:

``` puppet
   shellvar { 'x-port':
     variable => 'port',
     target   => '/etc/x',
     value    => '2034',
   }
   shellvar { 'y-port':
     variable => 'port',
     target   => '/etc/y',
     value    => '8107',
   }
```

This pull request fixes #120
