### PR TITLE
Before this, nil values would cause errors

### DIFF
--- a/lib/puppet/type/sysctl.rb
+++ b/lib/puppet/type/sysctl.rb
@@ -38,7 +38,7 @@ Puppet::Type.newtype(:sysctl) do
     end
 
     def equal(a, b)
-      a.gsub(/\s+/, ' ') == b.gsub(/\s+/, ' ')
+      not [a, b].include?(nil) and a.gsub(/\s+/, ' ') == b.gsub(/\s+/, ' ')
     end
   end
 


### PR DESCRIPTION
These could happen when the values on disk were missing but were running live on the
system.
