### PR TITLE
Update augeasproviders_grub dependency to include 3.1.0 release

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
     { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <6.0.0" },
     { "name": "herculesteam/augeasproviders_apache", "version_requirement": ">=3.1.0 <4.0.0" },
     { "name": "herculesteam/augeasproviders_base", "version_requirement": ">=2.1.0 <3.0.0" },
-    { "name": "herculesteam/augeasproviders_grub", "version_requirement": ">3.1.0 <4.0.0" },
+    { "name": "herculesteam/augeasproviders_grub", "version_requirement": ">=3.1.0 <4.0.0" },
     { "name": "herculesteam/augeasproviders_mounttab", "version_requirement": ">=2.1.0 <3.0.0" },
     { "name": "herculesteam/augeasproviders_nagios", "version_requirement": ">=2.1.0 <3.0.0" },
     { "name": "herculesteam/augeasproviders_pam", "version_requirement": ">=2.2.0 <3.0.0" },


### PR DESCRIPTION
In the 2.2.1 the augeasproviders_grub dependency is declared as followed:
` { "name": "herculesteam/augeasproviders_grub", "version_requirement": ">3.1.0 <4.0.0" },`
augeasproviders_grub was just released and the newest version is 3.1.0, which does not fill the requirements. Dependency should be updated to:
`">=3.1.0 <4.0.0"`