### PR TITLE
Resolve puppetserver log warnings caused by undefined global variables

### DIFF
--- a/manifests/instances.pp
+++ b/manifests/instances.pp
@@ -21,85 +21,85 @@ class augeasproviders::instances (
   $resource_defaults          = $augeasproviders::params::resource_defaults
 ) inherits augeasproviders::params {
 
-  validate_hash($resource_defaults)
+  validate_legacy(Hash, 'validate_hash', $resource_defaults)
 
   if $apache_directive_hash and !empty($apache_directive_hash) {
-    validate_hash($apache_directive_hash)
+    validate_legacy(Hash, 'validate_hash', $apache_directive_hash)
     create_resources(apache_directive, $apache_directive_hash, $resource_defaults['apache_directive'])
   }
 
   if $apache_setenv_hash and !empty($apache_setenv_hash) {
-    validate_hash($apache_setenv_hash)
+    validate_legacy(Hash, 'validate_hash', $apache_setenv_hash)
     create_resources(apache_setenv, $apache_setenv_hash, $resource_defaults['apache_setenv'])
   }
 
   if $host_hash and !empty($host_hash) {
-    validate_hash($host_hash)
+    validate_legacy(Hash, 'validate_hash', $host_hash)
     create_resources(host, $host_hash, $resource_defaults['host'])
   }
 
   if $kernel_parameter_hash and !empty($kernel_parameter_hash) {
-    validate_hash($kernel_parameter_hash)
+    validate_legacy(Hash, 'validate_hash', $kernel_parameter_hash)
     create_resources(kernel_parameter, $kernel_parameter_hash, $resource_defaults['kernel_parameter'])
   }
 
   if $mailalias_hash and !empty($mailalias_hash) {
-    validate_hash($mailalias_hash)
+    validate_legacy(Hash, 'validate_hash', $mailalias_hash)
     create_resources(mailalias, $mailalias_hash, $resource_defaults['mailalias'])
   }
 
   if $mounttab_hash and !empty($mounttab_hash) {
-    validate_hash($mounttab_hash)
+    validate_legacy(Hash, 'validate_hash', $mounttab_hash)
     create_resources(mounttab, $mounttab_hash, $resource_defaults['mounttab'])
   }
 
   if $nrpe_command_hash and !empty($nrpe_command_hash) {
-    validate_hash($nrpe_command_hash)
+    validate_legacy(Hash, 'validate_hash', $nrpe_command_hash)
     create_resources(nrpe_command, $nrpe_command_hash, $resource_defaults['nrpe_command'])
   }
 
   if $pam_hash and !empty($pam_hash) {
-    validate_hash($pam_hash)
+    validate_legacy(Hash, 'validate_hash', $pam_hash)
     create_resources(pam, $pam_hash, $resource_defaults['pam'])
   }
 
   if $pg_hba_hash and !empty($pg_hba_hash) {
-    validate_hash($pg_hba_hash)
+    validate_legacy(Hash, 'validate_hash', $pg_hba_hash)
     create_resources(pg_hba, $pg_hba_hash, $resource_defaults['pg_hba'])
   }
 
   if $puppet_auth_hash and !empty($puppet_auth_hash) {
-    validate_hash($puppet_auth_hash)
+    validate_legacy(Hash, 'validate_hash', $puppet_auth_hash)
     create_resources(puppet_auth, $puppet_auth_hash, $resource_defaults['puppet_auth'])
   }
 
   if $shellvar_hash and !empty($shellvar_hash) {
-    validate_hash($shellvar_hash)
+    validate_legacy(Hash, 'validate_hash', $shellvar_hash)
     create_resources(shellvar, $shellvar_hash, $resource_defaults['shellvar'])
   }
 
   if $ssh_config_hash and !empty($ssh_config_hash) {
-    validate_hash($ssh_config_hash)
+    validate_legacy(Hash, 'validate_hash', $ssh_config_hash)
     create_resources(ssh_config, $ssh_config_hash, $resource_defaults['ssh_config'])
   }
 
   if $sshd_config_hash and !empty($sshd_config_hash) {
-    validate_hash($sshd_config_hash)
+    validate_legacy(Hash, 'validate_hash', $sshd_config_hash)
     create_resources(sshd_config, $sshd_config_hash, $resource_defaults['sshd_config'])
   }
 
   if $sshd_config_subsystem_hash and !empty($sshd_config_subsystem_hash) {
-    validate_hash($sshd_config_subsystem_hash)
+    validate_legacy(Hash, 'validate_hash', $sshd_config_subsystem_hash)
     create_resources(sshd_config_subsystem, $sshd_config_subsystem_hash, $resource_defaults['sshd_config_subsystem'])
   }
 
   if $sysctl_hash and !empty($sysctl_hash) {
-    validate_hash($sysctl_hash)
+    validate_legacy(Hash, 'validate_hash', $sysctl_hash)
     create_resources(sysctl, $sysctl_hash, $resource_defaults['sysctl'])
   }
 
   if $syslog_hash and !empty($syslog_hash) {
-    validate_hash($syslog_hash)
+    validate_legacy(Hash, 'validate_hash', $syslog_hash)
     create_resources(syslog, $syslog_hash, $resource_defaults['syslog'])
   }
 

--- a/manifests/instances.pp
+++ b/manifests/instances.pp
@@ -2,104 +2,86 @@
 #
 # [Remember: No empty lines between comments and class definition]
 class augeasproviders::instances (
-  $apache_directive_hash      = $augeasproviders::params::apache_directive_hash,
-  $apache_setenv_hash         = $augeasproviders::params::apache_setenv_hash,
-  $host_hash                  = $augeasproviders::params::host_hash,
-  $kernel_parameter_hash      = $augeasproviders::params::kernel_parameter_hash,
-  $mailalias_hash             = $augeasproviders::params::mailalias_hash,
-  $mounttab_hash              = $augeasproviders::params::mounttab_hash,
-  $nrpe_command_hash          = $augeasproviders::params::nrpe_command_hash,
-  $pam_hash                   = $augeasproviders::params::pam_hash,
-  $pg_hba_hash                = $augeasproviders::params::pg_hba_hash,
-  $puppet_auth_hash           = $augeasproviders::params::puppet_auth_hash,
-  $shellvar_hash              = $augeasproviders::params::shellvar_hash,
-  $ssh_config_hash            = $augeasproviders::params::ssh_config_hash,
-  $sshd_config_hash           = $augeasproviders::params::sshd_config_hash,
-  $sshd_config_subsystem_hash = $augeasproviders::params::sshd_config_subsystem_hash,
-  $sysctl_hash                = $augeasproviders::params::sysctl_hash,
-  $syslog_hash                = $augeasproviders::params::syslog_hash,
-  $resource_defaults          = $augeasproviders::params::resource_defaults
+  Hash $apache_directive_hash      = $augeasproviders::params::apache_directive_hash,
+  Hash $apache_setenv_hash         = $augeasproviders::params::apache_setenv_hash,
+  Hash $host_hash                  = $augeasproviders::params::host_hash,
+  Hash $kernel_parameter_hash      = $augeasproviders::params::kernel_parameter_hash,
+  Hash $mailalias_hash             = $augeasproviders::params::mailalias_hash,
+  Hash $mounttab_hash              = $augeasproviders::params::mounttab_hash,
+  Hash $nrpe_command_hash          = $augeasproviders::params::nrpe_command_hash,
+  Hash $pam_hash                   = $augeasproviders::params::pam_hash,
+  Hash $pg_hba_hash                = $augeasproviders::params::pg_hba_hash,
+  Hash $puppet_auth_hash           = $augeasproviders::params::puppet_auth_hash,
+  Hash $shellvar_hash              = $augeasproviders::params::shellvar_hash,
+  Hash $ssh_config_hash            = $augeasproviders::params::ssh_config_hash,
+  Hash $sshd_config_hash           = $augeasproviders::params::sshd_config_hash,
+  Hash $sshd_config_subsystem_hash = $augeasproviders::params::sshd_config_subsystem_hash,
+  Hash $sysctl_hash                = $augeasproviders::params::sysctl_hash,
+  Hash $syslog_hash                = $augeasproviders::params::syslog_hash,
+  Hash $resource_defaults          = $augeasproviders::params::resource_defaults
 ) inherits augeasproviders::params {
 
-  validate_legacy(Hash, 'validate_hash', $resource_defaults)
-
   if $apache_directive_hash and !empty($apache_directive_hash) {
-    validate_legacy(Hash, 'validate_hash', $apache_directive_hash)
     create_resources(apache_directive, $apache_directive_hash, $resource_defaults['apache_directive'])
   }
 
   if $apache_setenv_hash and !empty($apache_setenv_hash) {
-    validate_legacy(Hash, 'validate_hash', $apache_setenv_hash)
     create_resources(apache_setenv, $apache_setenv_hash, $resource_defaults['apache_setenv'])
   }
 
   if $host_hash and !empty($host_hash) {
-    validate_legacy(Hash, 'validate_hash', $host_hash)
     create_resources(host, $host_hash, $resource_defaults['host'])
   }
 
   if $kernel_parameter_hash and !empty($kernel_parameter_hash) {
-    validate_legacy(Hash, 'validate_hash', $kernel_parameter_hash)
     create_resources(kernel_parameter, $kernel_parameter_hash, $resource_defaults['kernel_parameter'])
   }
 
   if $mailalias_hash and !empty($mailalias_hash) {
-    validate_legacy(Hash, 'validate_hash', $mailalias_hash)
     create_resources(mailalias, $mailalias_hash, $resource_defaults['mailalias'])
   }
 
   if $mounttab_hash and !empty($mounttab_hash) {
-    validate_legacy(Hash, 'validate_hash', $mounttab_hash)
     create_resources(mounttab, $mounttab_hash, $resource_defaults['mounttab'])
   }
 
   if $nrpe_command_hash and !empty($nrpe_command_hash) {
-    validate_legacy(Hash, 'validate_hash', $nrpe_command_hash)
     create_resources(nrpe_command, $nrpe_command_hash, $resource_defaults['nrpe_command'])
   }
 
   if $pam_hash and !empty($pam_hash) {
-    validate_legacy(Hash, 'validate_hash', $pam_hash)
     create_resources(pam, $pam_hash, $resource_defaults['pam'])
   }
 
   if $pg_hba_hash and !empty($pg_hba_hash) {
-    validate_legacy(Hash, 'validate_hash', $pg_hba_hash)
     create_resources(pg_hba, $pg_hba_hash, $resource_defaults['pg_hba'])
   }
 
   if $puppet_auth_hash and !empty($puppet_auth_hash) {
-    validate_legacy(Hash, 'validate_hash', $puppet_auth_hash)
     create_resources(puppet_auth, $puppet_auth_hash, $resource_defaults['puppet_auth'])
   }
 
   if $shellvar_hash and !empty($shellvar_hash) {
-    validate_legacy(Hash, 'validate_hash', $shellvar_hash)
     create_resources(shellvar, $shellvar_hash, $resource_defaults['shellvar'])
   }
 
   if $ssh_config_hash and !empty($ssh_config_hash) {
-    validate_legacy(Hash, 'validate_hash', $ssh_config_hash)
     create_resources(ssh_config, $ssh_config_hash, $resource_defaults['ssh_config'])
   }
 
   if $sshd_config_hash and !empty($sshd_config_hash) {
-    validate_legacy(Hash, 'validate_hash', $sshd_config_hash)
     create_resources(sshd_config, $sshd_config_hash, $resource_defaults['sshd_config'])
   }
 
   if $sshd_config_subsystem_hash and !empty($sshd_config_subsystem_hash) {
-    validate_legacy(Hash, 'validate_hash', $sshd_config_subsystem_hash)
     create_resources(sshd_config_subsystem, $sshd_config_subsystem_hash, $resource_defaults['sshd_config_subsystem'])
   }
 
   if $sysctl_hash and !empty($sysctl_hash) {
-    validate_legacy(Hash, 'validate_hash', $sysctl_hash)
     create_resources(sysctl, $sysctl_hash, $resource_defaults['sysctl'])
   }
 
   if $syslog_hash and !empty($syslog_hash) {
-    validate_legacy(Hash, 'validate_hash', $syslog_hash)
     create_resources(syslog, $syslog_hash, $resource_defaults['syslog'])
   }
 

--- a/manifests/instances.pp
+++ b/manifests/instances.pp
@@ -2,87 +2,40 @@
 #
 # [Remember: No empty lines between comments and class definition]
 class augeasproviders::instances (
-  Hash $apache_directive_hash      = $augeasproviders::params::apache_directive_hash,
-  Hash $apache_setenv_hash         = $augeasproviders::params::apache_setenv_hash,
-  Hash $host_hash                  = $augeasproviders::params::host_hash,
-  Hash $kernel_parameter_hash      = $augeasproviders::params::kernel_parameter_hash,
-  Hash $mailalias_hash             = $augeasproviders::params::mailalias_hash,
-  Hash $mounttab_hash              = $augeasproviders::params::mounttab_hash,
-  Hash $nrpe_command_hash          = $augeasproviders::params::nrpe_command_hash,
-  Hash $pam_hash                   = $augeasproviders::params::pam_hash,
-  Hash $pg_hba_hash                = $augeasproviders::params::pg_hba_hash,
-  Hash $puppet_auth_hash           = $augeasproviders::params::puppet_auth_hash,
-  Hash $shellvar_hash              = $augeasproviders::params::shellvar_hash,
-  Hash $ssh_config_hash            = $augeasproviders::params::ssh_config_hash,
-  Hash $sshd_config_hash           = $augeasproviders::params::sshd_config_hash,
-  Hash $sshd_config_subsystem_hash = $augeasproviders::params::sshd_config_subsystem_hash,
-  Hash $sysctl_hash                = $augeasproviders::params::sysctl_hash,
-  Hash $syslog_hash                = $augeasproviders::params::syslog_hash,
-  Hash $resource_defaults          = $augeasproviders::params::resource_defaults
+  Hash[String, Hash] $apache_directive_hash      = {},
+  Hash[String, Hash] $apache_setenv_hash         = {},
+  Hash[String, Hash] $host_hash                  = {},
+  Hash[String, Hash] $kernel_parameter_hash      = {},
+  Hash[String, Hash] $mailalias_hash             = {},
+  Hash[String, Hash] $mounttab_hash              = {},
+  Hash[String, Hash] $nrpe_command_hash          = {},
+  Hash[String, Hash] $pam_hash                   = {},
+  Hash[String, Hash] $pg_hba_hash                = {},
+  Hash[String, Hash] $puppet_auth_hash           = {},
+  Hash[String, Hash] $shellvar_hash              = {},
+  Hash[String, Hash] $ssh_config_hash            = {},
+  Hash[String, Hash] $sshd_config_hash           = {},
+  Hash[String, Hash] $sshd_config_subsystem_hash = {},
+  Hash[String, Hash] $sysctl_hash                = {},
+  Hash[String, Hash] $syslog_hash                = {},
+  Hash[String, Hash] $resource_defaults          = $augeasproviders::params::resource_defaults,
 ) inherits augeasproviders::params {
 
-  if $apache_directive_hash and !empty($apache_directive_hash) {
-    create_resources(apache_directive, $apache_directive_hash, $resource_defaults['apache_directive'])
-  }
-
-  if $apache_setenv_hash and !empty($apache_setenv_hash) {
-    create_resources(apache_setenv, $apache_setenv_hash, $resource_defaults['apache_setenv'])
-  }
-
-  if $host_hash and !empty($host_hash) {
-    create_resources(host, $host_hash, $resource_defaults['host'])
-  }
-
-  if $kernel_parameter_hash and !empty($kernel_parameter_hash) {
-    create_resources(kernel_parameter, $kernel_parameter_hash, $resource_defaults['kernel_parameter'])
-  }
-
-  if $mailalias_hash and !empty($mailalias_hash) {
-    create_resources(mailalias, $mailalias_hash, $resource_defaults['mailalias'])
-  }
-
-  if $mounttab_hash and !empty($mounttab_hash) {
-    create_resources(mounttab, $mounttab_hash, $resource_defaults['mounttab'])
-  }
-
-  if $nrpe_command_hash and !empty($nrpe_command_hash) {
-    create_resources(nrpe_command, $nrpe_command_hash, $resource_defaults['nrpe_command'])
-  }
-
-  if $pam_hash and !empty($pam_hash) {
-    create_resources(pam, $pam_hash, $resource_defaults['pam'])
-  }
-
-  if $pg_hba_hash and !empty($pg_hba_hash) {
-    create_resources(pg_hba, $pg_hba_hash, $resource_defaults['pg_hba'])
-  }
-
-  if $puppet_auth_hash and !empty($puppet_auth_hash) {
-    create_resources(puppet_auth, $puppet_auth_hash, $resource_defaults['puppet_auth'])
-  }
-
-  if $shellvar_hash and !empty($shellvar_hash) {
-    create_resources(shellvar, $shellvar_hash, $resource_defaults['shellvar'])
-  }
-
-  if $ssh_config_hash and !empty($ssh_config_hash) {
-    create_resources(ssh_config, $ssh_config_hash, $resource_defaults['ssh_config'])
-  }
-
-  if $sshd_config_hash and !empty($sshd_config_hash) {
-    create_resources(sshd_config, $sshd_config_hash, $resource_defaults['sshd_config'])
-  }
-
-  if $sshd_config_subsystem_hash and !empty($sshd_config_subsystem_hash) {
-    create_resources(sshd_config_subsystem, $sshd_config_subsystem_hash, $resource_defaults['sshd_config_subsystem'])
-  }
-
-  if $sysctl_hash and !empty($sysctl_hash) {
-    create_resources(sysctl, $sysctl_hash, $resource_defaults['sysctl'])
-  }
-
-  if $syslog_hash and !empty($syslog_hash) {
-    create_resources(syslog, $syslog_hash, $resource_defaults['syslog'])
-  }
+  create_resources(apache_directive, $apache_directive_hash, $resource_defaults['apache_directive'])
+  create_resources(apache_setenv, $apache_setenv_hash, $resource_defaults['apache_setenv'])
+  create_resources(host, $host_hash, $resource_defaults['host'])
+  create_resources(kernel_parameter, $kernel_parameter_hash, $resource_defaults['kernel_parameter'])
+  create_resources(mailalias, $mailalias_hash, $resource_defaults['mailalias'])
+  create_resources(mounttab, $mounttab_hash, $resource_defaults['mounttab'])
+  create_resources(nrpe_command, $nrpe_command_hash, $resource_defaults['nrpe_command'])
+  create_resources(pam, $pam_hash, $resource_defaults['pam'])
+  create_resources(pg_hba, $pg_hba_hash, $resource_defaults['pg_hba'])
+  create_resources(puppet_auth, $puppet_auth_hash, $resource_defaults['puppet_auth'])
+  create_resources(shellvar, $shellvar_hash, $resource_defaults['shellvar'])
+  create_resources(ssh_config, $ssh_config_hash, $resource_defaults['ssh_config'])
+  create_resources(sshd_config, $sshd_config_hash, $resource_defaults['sshd_config'])
+  create_resources(sshd_config_subsystem, $sshd_config_subsystem_hash, $resource_defaults['sshd_config_subsystem'])
+  create_resources(sysctl, $sysctl_hash, $resource_defaults['sysctl'])
+  create_resources(syslog, $syslog_hash, $resource_defaults['syslog'])
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,105 +1,8 @@
 # Class: augeasproviders::augeasproviders_params
 #
-# Defines all the variables used in the module.
+# Sets defaults behaviour to all directives
 #
 class augeasproviders::params {
-
-  $apache_directive_hash = lookup({
-    'name'          => 'augeasproviders_apache_directive_hash',
-    'value_type'    => Hash,
-    'default_value' => {},
-  })
-
-  $apache_setenv_hash = lookup({
-    'name'          => 'augeasproviders_apache_setenv_hash',
-    'value_type'    => Hash,
-    'default_value' => {},
-  })
-
-  $host_hash = lookup({
-    'name'          => 'augeasproviders_host_hash',
-    'value_type'    => Hash,
-    'default_value' => {},
-  })
-
-  $kernel_parameter_hash = lookup({
-    'name'          => 'augeasproviders_kernel_parameter_hash',
-    'value_type'    => Hash,
-    'default_value' => {},
-  })
-
-  $mailalias_hash = lookup({
-    'name'          => 'augeasproviders_mailalias_hash',
-    'value_type'    => Hash,
-    'default_value' => {},
-  })
-
-  $mounttab_hash = lookup({
-    'name'          => 'augeasproviders_mounttab_hash',
-    'value_type'    => Hash,
-    'default_value' => {},
-  })
-
-  $nrpe_command_hash = lookup({
-    'name'          => 'augeasproviders_nrpe_command_hash',
-    'value_type'    => Hash,
-    'default_value' => {},
-  })
-
-  $pam_hash = lookup({
-    'name'          => 'augeasproviders_pam_hash',
-    'value_type'    => Hash,
-    'default_value' => {},
-  })
-
-  $pg_hba_hash = lookup({
-    'name'          => 'augeasproviders_pg_hba_hash',
-    'value_type'    => Hash,
-    'default_value' => {},
-  })
-
-  $puppet_auth_hash = lookup({
-    'name'          => 'augeasproviders_puppet_auth_hash',
-    'value_type'    => Hash,
-    'default_value' => {},
-  })
-
-  $shellvar_hash = lookup({
-    'name'          => 'augeasproviders_shellvar_hash',
-    'value_type'    => Hash,
-    'default_value' => {},
-  })
-
-  $ssh_config_hash = lookup({
-    'name'          => 'augeasproviders_ssh_config_hash',
-    'value_type'    => Hash,
-    'default_value' => {},
-  })
-
-  $sshd_config_hash = lookup({
-    'name'          => 'augeasproviders_sshd_config_hash',
-    'value_type'    => Hash,
-    'default_value' => {},
-  })
-
-  $sshd_config_subsystem_hash = lookup({
-    'name'          => 'augeasproviders_sshd_config_subsystem_hash',
-    'value_type'    => Hash,
-    'default_value' => {},
-  })
-
-  $sysctl_hash = lookup({
-    'name'          => 'augeasproviders_sysctl_hash',
-    'value_type'    => Hash,
-    'default_value' => {},
-  })
-
-  $syslog_hash = lookup({
-    'name'          => 'augeasproviders_syslog_hash',
-    'value_type'    => Hash,
-    'default_value' => {},
-  })
-
   $defaults = {
     'ensure'    => 'present',
     'provider'  => 'augeas',
@@ -117,6 +20,7 @@ class augeasproviders::params {
     'pg_hba'                => $defaults,
     'puppet_auth'           => $defaults,
     'shellvar'              => $defaults,
+    'ssh_config'            => $defaults,
     'sshd_config'           => $defaults,
     'sshd_config_subsystem' => $defaults,
     'sysctl'                => $defaults,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,85 +4,101 @@
 #
 class augeasproviders::params {
 
-  $apache_directive_hash = $facts['augeasproviders_apache_directive_hash'] ? {
-    undef   => false,
-    default => $::augeasproviders_apache_directive_hash,
-  }
+  $apache_directive_hash = lookup({
+    'name'          => 'augeasproviders_apache_directive_hash',
+    'value_type'    => Hash,
+    'default_value' => {},
+  })
 
-  $apache_setenv_hash = $facts['augeasproviders_apache_setenv_hash'] ? {
-    undef   => false,
-    default => $::augeasproviders_apache_setenv_hash,
-  }
+  $apache_setenv_hash = lookup({
+    'name'          => 'augeasproviders_apache_setenv_hash',
+    'value_type'    => Hash,
+    'default_value' => {},
+  })
 
-  $host_hash = $facts['augeasproviders_host_hash'] ? {
-    undef   => false,
-    default => $::augeasproviders_host_hash,
-  }
+  $host_hash = lookup({
+    'name'          => 'augeasproviders_host_hash',
+    'value_type'    => Hash,
+    'default_value' => {},
+  })
 
-  $kernel_parameter_hash = $facts['augeasproviders_kernel_parameter_hash'] ? {
-    undef   => false,
-    default => $::augeasproviders_kernel_parameter_hash,
-  }
+  $kernel_parameter_hash = lookup({
+    'name'          => 'augeasproviders_kernel_parameter_hash',
+    'value_type'    => Hash,
+    'default_value' => {},
+  })
 
-  $mailalias_hash = $facts['augeasproviders_mailalias_hash'] ? {
-    undef   => false,
-    default => $::augeasproviders_mailalias_hash,
-  }
+  $mailalias_hash = lookup({
+    'name'          => 'augeasproviders_mailalias_hash',
+    'value_type'    => Hash,
+    'default_value' => {},
+  })
 
-  $mounttab_hash = $facts['augeasproviders_mounttab_hash'] ? {
-    undef   => false,
-    default => $::augeasproviders_mounttab_hash,
-  }
+  $mounttab_hash = lookup({
+    'name'          => 'augeasproviders_mounttab_hash',
+    'value_type'    => Hash,
+    'default_value' => {},
+  })
 
-  $nrpe_command_hash = $facts['augeasproviders_nrpe_command_hash'] ? {
-    undef   => false,
-    default => $::augeasproviders_nrpe_command_hash,
-  }
+  $nrpe_command_hash = lookup({
+    'name'          => 'augeasproviders_nrpe_command_hash',
+    'value_type'    => Hash,
+    'default_value' => {},
+  })
 
-  $pam_hash = $facts['augeasproviders_pam_hash'] ? {
-    undef   => false,
-    default => $::augeasproviders_pam_hash,
-  }
+  $pam_hash = lookup({
+    'name'          => 'augeasproviders_pam_hash',
+    'value_type'    => Hash,
+    'default_value' => {},
+  })
 
-  $pg_hba_hash = $facts['augeasproviders_pg_hba_hash'] ? {
-    undef   => false,
-    default => $::augeasproviders_pg_hba_hash,
-  }
+  $pg_hba_hash = lookup({
+    'name'          => 'augeasproviders_pg_hba_hash',
+    'value_type'    => Hash,
+    'default_value' => {},
+  })
 
-  $puppet_auth_hash = $facts['augeasproviders_puppet_auth_hash'] ? {
-    undef   => false,
-    default => $::augeasproviders_puppet_auth_hash,
-  }
+  $puppet_auth_hash = lookup({
+    'name'          => 'augeasproviders_puppet_auth_hash',
+    'value_type'    => Hash,
+    'default_value' => {},
+  })
 
-  $shellvar_hash = $facts['augeasproviders_shellvar_hash'] ? {
-    undef   => false,
-    default => $::augeasproviders_shellvar_hash,
-  }
+  $shellvar_hash = lookup({
+    'name'          => 'augeasproviders_shellvar_hash',
+    'value_type'    => Hash,
+    'default_value' => {},
+  })
 
-  $ssh_config_hash = $facts['augeasproviders_ssh_config_hash'] ? {
-    undef   => false,
-    default => $::augeasproviders_ssh_config_hash,
-  }
+  $ssh_config_hash = lookup({
+    'name'          => 'augeasproviders_ssh_config_hash',
+    'value_type'    => Hash,
+    'default_value' => {},
+  })
 
-  $sshd_config_hash = $facts['augeasproviders_sshd_config_hash'] ? {
-    undef   => false,
-    default => $::augeasproviders_sshd_config_hash,
-  }
+  $sshd_config_hash = lookup({
+    'name'          => 'augeasproviders_sshd_config_hash',
+    'value_type'    => Hash,
+    'default_value' => {},
+  })
 
-  $sshd_config_subsystem_hash = $facts['augeasproviders_sshd_config_subsystem_hash'] ? {
-    undef   => false,
-    default => $::augeasproviders_sshd_config_subsystem_hash,
-  }
+  $sshd_config_subsystem_hash = lookup({
+    'name'          => 'augeasproviders_sshd_config_subsystem_hash',
+    'value_type'    => Hash,
+    'default_value' => {},
+  })
 
-  $sysctl_hash = $facts['augeasproviders_sysctl_hash'] ? {
-    undef   => false,
-    default => $::augeasproviders_sysctl_hash,
-  }
+  $sysctl_hash = lookup({
+    'name'          => 'augeasproviders_sysctl_hash',
+    'value_type'    => Hash,
+    'default_value' => {},
+  })
 
-  $syslog_hash = $facts['augeasproviders_syslog_hash'] ? {
-    undef   => false,
-    default => $::augeasproviders_syslog_hash,
-  }
+  $syslog_hash = lookup({
+    'name'          => 'augeasproviders_syslog_hash',
+    'value_type'    => Hash,
+    'default_value' => {},
+  })
 
   $defaults = {
     'ensure'    => 'present',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,82 +4,82 @@
 #
 class augeasproviders::params {
 
-  $apache_directive_hash = $::augeasproviders_apache_directive_hash ? {
+  $apache_directive_hash = $facts['augeasproviders_apache_directive_hash'] ? {
     undef   => false,
     default => $::augeasproviders_apache_directive_hash,
   }
 
-  $apache_setenv_hash = $::augeasproviders_apache_setenv_hash ? {
+  $apache_setenv_hash = $facts['augeasproviders_apache_setenv_hash'] ? {
     undef   => false,
     default => $::augeasproviders_apache_setenv_hash,
   }
 
-  $host_hash = $::augeasproviders_host_hash ? {
+  $host_hash = $facts['augeasproviders_host_hash'] ? {
     undef   => false,
     default => $::augeasproviders_host_hash,
   }
 
-  $kernel_parameter_hash = $::augeasproviders_kernel_parameter_hash ? {
+  $kernel_parameter_hash = $facts['augeasproviders_kernel_parameter_hash'] ? {
     undef   => false,
     default => $::augeasproviders_kernel_parameter_hash,
   }
 
-  $mailalias_hash = $::augeasproviders_mailalias_hash ? {
+  $mailalias_hash = $facts['augeasproviders_mailalias_hash'] ? {
     undef   => false,
     default => $::augeasproviders_mailalias_hash,
   }
 
-  $mounttab_hash = $::augeasproviders_mounttab_hash ? {
+  $mounttab_hash = $facts['augeasproviders_mounttab_hash'] ? {
     undef   => false,
     default => $::augeasproviders_mounttab_hash,
   }
 
-  $nrpe_command_hash = $::augeasproviders_nrpe_command_hash ? {
+  $nrpe_command_hash = $facts['augeasproviders_nrpe_command_hash'] ? {
     undef   => false,
     default => $::augeasproviders_nrpe_command_hash,
   }
 
-  $pam_hash = $::augeasproviders_pam_hash ? {
+  $pam_hash = $facts['augeasproviders_pam_hash'] ? {
     undef   => false,
     default => $::augeasproviders_pam_hash,
   }
 
-  $pg_hba_hash = $::augeasproviders_pg_hba_hash ? {
+  $pg_hba_hash = $facts['augeasproviders_pg_hba_hash'] ? {
     undef   => false,
     default => $::augeasproviders_pg_hba_hash,
   }
 
-  $puppet_auth_hash = $::augeasproviders_puppet_auth_hash ? {
+  $puppet_auth_hash = $facts['augeasproviders_puppet_auth_hash'] ? {
     undef   => false,
     default => $::augeasproviders_puppet_auth_hash,
   }
 
-  $shellvar_hash = $::augeasproviders_shellvar_hash ? {
+  $shellvar_hash = $facts['augeasproviders_shellvar_hash'] ? {
     undef   => false,
     default => $::augeasproviders_shellvar_hash,
   }
 
-  $ssh_config_hash = $::augeasproviders_ssh_config_hash ? {
+  $ssh_config_hash = $facts['augeasproviders_ssh_config_hash'] ? {
     undef   => false,
     default => $::augeasproviders_ssh_config_hash,
   }
 
-  $sshd_config_hash = $::augeasproviders_sshd_config_hash ? {
+  $sshd_config_hash = $facts['augeasproviders_sshd_config_hash'] ? {
     undef   => false,
     default => $::augeasproviders_sshd_config_hash,
   }
 
-  $sshd_config_subsystem_hash = $::augeasproviders_sshd_config_subsystem_hash ? {
+  $sshd_config_subsystem_hash = $facts['augeasproviders_sshd_config_subsystem_hash'] ? {
     undef   => false,
     default => $::augeasproviders_sshd_config_subsystem_hash,
   }
 
-  $sysctl_hash = $::augeasproviders_sysctl_hash ? {
+  $sysctl_hash = $facts['augeasproviders_sysctl_hash'] ? {
     undef   => false,
     default => $::augeasproviders_sysctl_hash,
   }
 
-  $syslog_hash = $::augeasproviders_syslog_hash ? {
+  $syslog_hash = $facts['augeasproviders_syslog_hash'] ? {
     undef   => false,
     default => $::augeasproviders_syslog_hash,
   }


### PR DESCRIPTION
Since puppet6, undefined global variables emit warnings in the puppetserver logs.
Changing the value to a facts[''] value resolves it while still honouring the ability to pass in provider values via hieradata.
Also addressing the deprecation of the validate_hash function.
Related post regarding this found here: https://access.redhat.com/discussions/5672161#comment-now