### PR TITLE
Dependency and Support Bump

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,19 +9,58 @@
   "issues_url": "https://github.com/hercules-team/augeasproviders_core/issues",
   "description": "This module provides alternative providers for core Puppet types using the Augeas configuration API library.",
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <6.0.0" },
-    { "name": "herculesteam/augeasproviders_apache", "version_requirement": ">=3.1.0 <4.0.0" },
-    { "name": "herculesteam/augeasproviders_base", "version_requirement": ">=2.1.0 <3.0.0" },
-    { "name": "herculesteam/augeasproviders_grub", "version_requirement": ">=3.1.0 <4.0.0" },
-    { "name": "herculesteam/augeasproviders_mounttab", "version_requirement": ">=2.1.0 <3.0.0" },
-    { "name": "herculesteam/augeasproviders_nagios", "version_requirement": ">=2.1.0 <3.0.0" },
-    { "name": "herculesteam/augeasproviders_pam", "version_requirement": ">=2.2.0 <3.0.0" },
-    { "name": "herculesteam/augeasproviders_postgresql", "version_requirement": ">=3.1.0 <4.0.0" },
-    { "name": "herculesteam/augeasproviders_puppet", "version_requirement": ">=2.2.0 <3.0.0" },
-    { "name": "herculesteam/augeasproviders_shellvar", "version_requirement": ">=3.1.0 <5.0.0" },
-    { "name": "herculesteam/augeasproviders_ssh", "version_requirement": ">=3.2.0 <4.0.0" },
-    { "name": "herculesteam/augeasproviders_sysctl", "version_requirement": ">=2.3.0 <3.0.0" },
-    { "name": "herculesteam/augeasproviders_syslog", "version_requirement": ">=2.2.0 <3.0.0" }
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 3.2.0 < 9.0.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_apache",
+      "version_requirement": ">=3.1.0 <4.0.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_base",
+      "version_requirement": ">=2.1.0 <3.0.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_grub",
+      "version_requirement": ">=3.1.0 <4.0.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_mounttab",
+      "version_requirement": ">=2.1.0 <3.0.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_nagios",
+      "version_requirement": ">=2.1.0 <3.0.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_pam",
+      "version_requirement": ">=2.2.0 <3.0.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_postgresql",
+      "version_requirement": ">=3.1.0 <4.0.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_puppet",
+      "version_requirement": ">=2.2.0 <3.0.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_shellvar",
+      "version_requirement": ">=3.1.0 <5.0.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_ssh",
+      "version_requirement": ">=3.2.0 <5.0.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_sysctl",
+      "version_requirement": ">=2.3.0 <3.0.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_syslog",
+      "version_requirement": ">=2.2.0 <3.0.0"
+    }
   ],
   "operatingsystem_support": [
     {
@@ -38,32 +77,61 @@
         "14.04",
         "16.04",
         "18.04",
-        "18.10"
+        "18.10",
+        "20.04"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "35",
+        "36"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     }
   ],
   "requirements": [
-    { "name": "puppet", "version_requirement": ">= 5.0.0 < 7.0.0" }
+    {
+      "name": "puppet",
+      "version_requirement": ">= 5.0.0 < 8.0.0"
+    }
   ]
 }


### PR DESCRIPTION
* Bumped `puppetlabs/stdlib` to < 9.0.0
* Bumped `herculesteam/augeasproviders_ssh` to < 5.0.0
* Bumped puppet version to < 8.0.0
* Updated OS support to latest known releases
* Added support for Rocky and Alma Linux
