### PR TITLE
Revert dependencies for not yet released modules

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
       "version_requirement": ">=2.1.0 <3.0.0"
     },
     {
-      "name": "puppet/augeasproviders_nagios",
+      "name": "herculesteam/augeasproviders_nagios",
       "version_requirement": ">=2.1.0 <3.0.0"
     },
     {
@@ -42,7 +42,7 @@
       "version_requirement": ">=3.1.0 <4.0.0"
     },
     {
-      "name": "puppet/augeasproviders_puppet",
+      "name": "herculesteam/augeasproviders_puppet",
       "version_requirement": ">=2.2.0 <3.0.0"
     },
     {
@@ -58,7 +58,7 @@
       "version_requirement": ">=2.3.0 <3.0.0"
     },
     {
-      "name": "puppet/augeasproviders_syslog",
+      "name": "herculesteam/augeasproviders_syslog",
       "version_requirement": ">=2.2.0 <3.0.0"
     }
   ],


### PR DESCRIPTION
Partial reversion of #179 as some of the dependencies havent had a release on voxpupuli namespace yet and therefore cause all sorts of failures.