### PR TITLE
puppet/augeasproviders_syslog: Allow 3.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -59,7 +59,7 @@
     },
     {
       "name": "puppet/augeasproviders_syslog",
-      "version_requirement": ">=2.2.0 <3.0.0"
+      "version_requirement": ">=2.2.0 <4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
includes: #181 #182 