### PR TITLE
puppet/augeasproviders_ssh: Allow 6.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "puppet/augeasproviders_grub",
-      "version_requirement": ">=3.1.0 <4.0.0"
+      "version_requirement": ">=3.1.0 <6.0.0"
     },
     {
       "name": "puppet/augeasproviders_mounttab",

--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,7 @@
     },
     {
       "name": "puppet/augeasproviders_pam",
-      "version_requirement": ">=2.2.0 <3.0.0"
+      "version_requirement": ">=2.2.0 <5.0.0"
     },
     {
       "name": "puppet/augeasproviders_postgresql",

--- a/metadata.json
+++ b/metadata.json
@@ -47,7 +47,7 @@
     },
     {
       "name": "puppet/augeasproviders_shellvar",
-      "version_requirement": ">=3.1.0 <5.0.0"
+      "version_requirement": ">=3.1.0 <7.0.0"
     },
     {
       "name": "puppet/augeasproviders_ssh",

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "puppet/augeasproviders_apache",
-      "version_requirement": ">=3.1.0 <4.0.0"
+      "version_requirement": ">=3.1.0 <6.0.0"
     },
     {
       "name": "puppet/augeasproviders_base",

--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
     },
     {
       "name": "puppet/augeasproviders_ssh",
-      "version_requirement": ">=3.2.0 <5.0.0"
+      "version_requirement": ">=3.2.0 <7.0.0"
     },
     {
       "name": "puppet/augeasproviders_sysctl",

--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "puppet/augeasproviders_mounttab",
-      "version_requirement": ">=2.1.0 <3.0.0"
+      "version_requirement": ">=2.1.0 <5.0.0"
     },
     {
       "name": "puppet/augeasproviders_nagios",

--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "puppet/augeasproviders_base",
-      "version_requirement": ">=2.1.0 <3.0.0"
+      "version_requirement": ">=2.1.0 <5.0.0"
     },
     {
       "name": "puppet/augeasproviders_grub",

--- a/metadata.json
+++ b/metadata.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "puppet/augeasproviders_postgresql",
-      "version_requirement": ">=3.1.0 <4.0.0"
+      "version_requirement": ">=3.1.0 <6.0.0"
     },
     {
       "name": "puppet/augeasproviders_puppet",


### PR DESCRIPTION
includes: #186 #187 #188 #189 #190 #191 #192 