### PR TITLE
Allow `puppet-augeasproviders_ssh` 7.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
     },
     {
       "name": "puppet/augeasproviders_ssh",
-      "version_requirement": ">=3.2.0 <7.0.0"
+      "version_requirement": ">= 3.2.0 < 8.0.0"
     },
     {
       "name": "puppet/augeasproviders_sysctl",


### PR DESCRIPTION
    Ref: https://github.com/voxpupuli/community-triage/issues/44
